### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/remootio/__init__.py
+++ b/custom_components/remootio/__init__.py
@@ -42,7 +42,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass_data = hass.data.setdefault(DOMAIN, {}).setdefault(entry.entry_id, {})
     hass_data[REMOOTIO_CLIENT] = remootio_client
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
Update __init__.py to prepare for home assistant 2023.3

Logger: homeassistant.helpers.frame
Source: helpers/frame.py:77
First occurred: 5:23:16 PM (1 occurrences)
Last logged: 5:23:16 PM

Detected integration that called async_setup_platforms instead of awaiting async_forward_entry_setups; this will fail in version 2023.3. Please report issue to the custom integration author for remootio using this method at custom_components/remootio/init.py, line 45: hass.config_entries.async_setup_platforms(entry, PLATFORMS)