### PR TITLE
Update cover.py to fix for HA 2023.9.0

### DIFF
--- a/custom_components/remootio/cover.py
+++ b/custom_components/remootio/cover.py
@@ -55,7 +55,7 @@ class RemootioCover(cover.CoverEntity):
     _remootio_client: RemootioClient
     _attr_has_entity_name = True
     _attr_should_poll = False
-    _attr_supported_features = cover.SUPPORT_OPEN | cover.SUPPORT_CLOSE
+    _attr_supported_features = cover.CoverEntityFeature.OPEN | cover.CoverEntityFeature.CLOSE
     def __init__(
         self,
         unique_id: str,

--- a/custom_components/remootio/cover.py
+++ b/custom_components/remootio/cover.py
@@ -51,6 +51,7 @@ async def async_setup_entry(
 class RemootioCover(cover.CoverEntity):
     """Cover entity which represents an Remootio device controlled garage door or gate."""
 
+    _attr_name = None
     _remootio_client: RemootioClient
     _attr_has_entity_name = True
     _attr_should_poll = False
@@ -70,6 +71,7 @@ class RemootioCover(cover.CoverEntity):
         self._attr_device_info = DeviceInfo(
             name=name,
             manufacturer="Assemblabs Ltd",
+            identifiers={(DOMAIN, self._attr_unique_id)},
         )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/remootio/manifest.json
+++ b/custom_components/remootio/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/remootio",
   "version": "1.4",
-  "requirements": ["aioremootio==1.0.0a17"],
+  "requirements": ["aioremootio @ git+https://github.com/yarafie/aioremootio.git"],
   "ssdp": [],
   "homekit": {},
   "dependencies": [],

--- a/custom_components/remootio/manifest.json
+++ b/custom_components/remootio/manifest.json
@@ -9,6 +9,6 @@
   "ssdp": [],
   "homekit": {},
   "dependencies": [],
-  "codeowners": ["@ivgg-me modified by @yarafie"],
+  "codeowners": ["@yarafie original by @ivgg-me"],
   "iot_class": "local_push"
 }

--- a/custom_components/remootio/manifest.json
+++ b/custom_components/remootio/manifest.json
@@ -4,11 +4,11 @@
   "integration_type": "device",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/remootio",
-  "version": "1.4",
+  "version": "1.4.2",
   "requirements": ["aioremootio @ git+https://github.com/yarafie/aioremootio.git"],
   "ssdp": [],
   "homekit": {},
   "dependencies": [],
-  "codeowners": ["@ivgg-me"],
+  "codeowners": ["@ivgg-me modified by @yarafie"],
   "iot_class": "local_push"
 }

--- a/custom_components/remootio/manifest.json
+++ b/custom_components/remootio/manifest.json
@@ -9,6 +9,6 @@
   "ssdp": [],
   "homekit": {},
   "dependencies": [],
-  "codeowners": ["@yarafie original by @ivgg-me"],
+  "codeowners": ["@yarafie","@sam43434","@ivgg-me"],
   "iot_class": "local_push"
 }

--- a/custom_components/remootio/manifest.json
+++ b/custom_components/remootio/manifest.json
@@ -6,6 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/remootio",
   "version": "1.4.2",
   "requirements": ["aioremootio @ git+https://github.com/yarafie/aioremootio.git"],
+  "issue_tracker": "https://github.com/yarafie/remootio/issues",
   "ssdp": [],
   "homekit": {},
   "dependencies": [],

--- a/custom_components/remootio/manifest.json
+++ b/custom_components/remootio/manifest.json
@@ -4,7 +4,7 @@
   "integration_type": "device",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/remootio",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "requirements": ["aioremootio @ git+https://github.com/yarafie/aioremootio.git"],
   "issue_tracker": "https://github.com/yarafie/remootio/issues",
   "ssdp": [],


### PR DESCRIPTION
Update cover.py to fix for HA 2023.9.0 which was exhibited by the following errors/warnings in HA logs 

1. config entry: device info must include at least one of identifiers or connections

2. Entity None is implicitly using device name by not setting its name